### PR TITLE
Resolve memory leak and compiler warnings.

### DIFF
--- a/examples/interactive.c
+++ b/examples/interactive.c
@@ -14,6 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "str2argv.h"
 
 #define UNUSED    __attribute__((__unused__))
@@ -41,8 +44,10 @@ main(int argc UNUSED, char *argv[] UNUSED)
       fflush(stdout);
 
       if (str2argv(s, &margc, &margv, &errmsg) == 0) {
-         for (i = 0; i < margc; i++)
-            printf("\tmargv[%d] = '%s'\n", i, margv[i]); fflush(stdout);
+         for (i = 0; i < margc; i++) {
+            printf("\tmargv[%d] = '%s'\n", i, margv[i]);
+            fflush(stdout);
+         }
 
          untoked = argv2str(margc, margv);
          printf("un-toked string: \"%s\"\n", untoked);

--- a/src/str2argv.c
+++ b/src/str2argv.c
@@ -225,7 +225,10 @@ str2argv(const char *str, int *argc, char ***argv, const char **errmsg)
       return 1;
    }
 
-   (*argv)[*argc] = NULL;/*XXX*/
+   if ((*argv)[*argc] != NULL) {
+      free((*argv)[*argc]);
+      (*argv)[*argc] = NULL;/*XXX*/
+   }
 
    return 0;
 }


### PR DESCRIPTION
argv_finish_token() allocates a character array for the next token in argv. After parsing the full command line, str2argv() overwrites the pointer to the last token in argv with NULL, losing ARGV_MAX_TOKEN_LEN per function call.